### PR TITLE
PRD-2143: Add extra origin header for websocket

### DIFF
--- a/libs/shared/data-access/websocket/src/service.ts
+++ b/libs/shared/data-access/websocket/src/service.ts
@@ -17,11 +17,16 @@ export class SocketService {
 
   public init(token: string, onConnect: () => void, onDisconnect: () => void): void {
     if (this._socket) return;
+    const apiUrl = getApiUrl();
 
     this._socket = io(getApiUrl(), {
       path: webSocketConfig.path,
       transports: webSocketConfig.transports,
       auth: { token },
+      // NOTE: Workaround required for the socket to connect to the backend, which rejects WS connections without this header.
+      extraHeaders: {
+        Origin: apiUrl,
+      },
     });
 
     this._socket.on(SocketState.CONNECT, () => {


### PR DESCRIPTION
Because the backend does not support `null` values for [CORS_ALLOW_ORIGIN](https://docs.openwebui.com/getting-started/env-configuration/#cors_allow_origin) and this environmental variable is required, we use a workaround that manually injects the `Origin` header.

Task: https://app.clickup.com/t/24336023/PRD-2143